### PR TITLE
Exclude Non-Updatable Columns from Database Update Operations

### DIFF
--- a/services/database/config.json
+++ b/services/database/config.json
@@ -1,8 +1,21 @@
 {
 	"hostname": "localhost",
 	"port": "5432",
-	"username": "postgres",
+	"username": "",
 	"password": "",
-	"dbname": "",
-	"allowedTables": ["users", "applications", "server_address"]
+	"dbname": "pulsecoredb",
+	 "allowedTables": {
+        "applications": {
+            "allowed": true,
+            "nonUpdatableColumns": ["id", "app_identifier", "user_id", "date_created"]
+        },
+        "server_addresses": {
+            "allowed": true,
+            "nonUpdatableColumns": ["id", "address", "app_id", "tag", "date_added"]
+        },
+		"users": {
+            "allowed": true,
+            "nonUpdatableColumns": ["id", "email", "date_created"]
+        }
+    }
 }

--- a/services/database/src/dbutils/dbutils.go
+++ b/services/database/src/dbutils/dbutils.go
@@ -11,12 +11,22 @@ import (
 )
 
 type DBConfig struct {
-	Hostname      string   `json:"hostname"`
-	Port          string   `json:"port"`
-	Username      string   `json:"username"`
-	Password      string   `json:"password"`
-	DBName        string   `json:"dbname"`
-	AllowedTables []string `json:"allowedTables"`
+	Hostname      string                 `json:"hostname"`
+	Port          string                 `json:"port"`
+	Username      string                 `json:"username"`
+	Password      string                 `json:"password"`
+	DBName        string                 `json:"dbname"`
+	AllowedTables map[string]TableConfig `json:"allowedTables"`
+}
+
+type TableConfig struct {
+	NonUpdatableColumns []string `json:"nonUpdatableColumns"`
+}
+
+var config DBConfig
+
+func init() {
+	config, _ = LoadConfig("../config.json")
 }
 
 func InsertRecord(db *pgxpool.Pool, tableName string, record map[string]interface{}) error {
@@ -61,4 +71,12 @@ func LoadConfig(path string) (DBConfig, error) {
 	decoder := json.NewDecoder(file)
 	err = decoder.Decode(&config)
 	return config, err
+}
+
+func NonUpdatableColumns(tableName string) []string {
+	tableConfig, ok := config.AllowedTables[tableName]
+	if !ok {
+		return nil
+	}
+	return tableConfig.NonUpdatableColumns
 }

--- a/services/database/src/main.go
+++ b/services/database/src/main.go
@@ -36,7 +36,7 @@ func main() {
 	}
 
 	allowedTablesMap = make(map[string]bool)
-	for _, table := range config.AllowedTables {
+	for table := range config.AllowedTables {
 		allowedTablesMap[table] = true
 	}
 
@@ -179,6 +179,11 @@ func updateRecords(c *gin.Context) {
 		if _, ok := allowedTablesMap[tableName]; !ok {
 			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Invalid table name provided: %s", tableName)})
 			return
+		}
+
+		nonUpdatableCols := dbutils.NonUpdatableColumns(tableName)
+		for _, col := range nonUpdatableCols {
+			delete(record.Fields, col)
 		}
 
 		setClauses := make([]string, 0, len(record.Fields))


### PR DESCRIPTION
In this PR, we enhance our database update mechanism to respect a predefined list of "non-updatable" columns. By leveraging configurations, we can specify columns that should never be updated for specific tables. The changes introduced ensure that any attempts to update these columns are ignored at the application level:

1. Introduced a function to fetch "non-updatable" columns based on the table name.
2. Before executing an update operation, the system cross-references the columns to be updated with the "non-updatable" list.
3. Any matching columns are removed from the update operation, ensuring data integrity and consistency.

This feature safeguards critical fields in our database from unintentional modifications such as SQL injections, enhancing the robustness of our system.